### PR TITLE
Fix unloading Capcom driver

### DIFF
--- a/drvmap/native.hpp
+++ b/drvmap/native.hpp
@@ -106,6 +106,8 @@ namespace native
 		UNICODE_STRING str;
 		auto wservice = internal::make_path(service);
 		RtlInitUnicodeString(&str, wservice.c_str());
+
+		NTSTATUS status = ZwUnloadDriver(&str);
 		
 		if (!RegOpenKeyW(HKEY_LOCAL_MACHINE, L"system\\CurrentControlSet\\Services", &key))
 		{
@@ -113,6 +115,6 @@ namespace native
 		    RegCloseKey(key);
 		}
 
-		return ZwUnloadDriver(&str) >= 0;
+		return NT_SUCCESS(status);
 	}
 }


### PR DESCRIPTION
4d656a4 made unloading (and therefore also deleting) the Capcom driver always fail. This PR fixes the unload while still deleting the registry key.